### PR TITLE
Add target name normalization module and CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+*.log
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Target Name Normalization
+
+Utilities for heavy but non-destructive normalization of protein target names.
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Optional quality tools:
+
+```bash
+pip install black ruff mypy
+```
+
+## Usage
+
+```bash
+python main.py --input target_validation_new.csv --output normalized.csv
+```
+
+## Development
+
+Run formatting and tests:
+
+```bash
+ruff check .
+black --check .
+pytest
+mypy .
+```

--- a/main.py
+++ b/main.py
@@ -1,0 +1,55 @@
+"""CLI entry point for target name normalization."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import List
+
+import pandas as pd
+
+from mylib.io_utils import read_target_names, write_with_new_columns
+from mylib.transforms import NormalizationResult, normalize_target_name
+
+
+def configure_logging(level: str) -> None:
+    logging.basicConfig(level=getattr(logging, level.upper(), logging.INFO))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Normalize target names")
+    parser.add_argument("--input", required=True, help="Path to input CSV")
+    parser.add_argument("--output", required=True, help="Path to output CSV")
+    parser.add_argument("--column", default="target_name", help="Name column")
+    parser.add_argument("--log-level", default="INFO", help="Logging level")
+    return parser.parse_args()
+
+
+def normalize_dataframe(df: pd.DataFrame, column: str) -> pd.DataFrame:
+    results: List[NormalizationResult] = [
+        normalize_target_name(str(val)) for val in df[column]
+    ]
+    df = df.copy()
+    df["clean_text"] = [r.clean_text for r in results]
+    df["query_tokens"] = [" ".join(r.query_tokens) for r in results]
+    df["gene_like_candidates"] = [" ".join(r.gene_like_candidates) for r in results]
+    df["hints"] = [json.dumps(r.hints, ensure_ascii=False) for r in results]
+    df["rules_applied"] = [" ".join(r.rules_applied) for r in results]
+    df["hint_taxon"] = [r.hint_taxon for r in results]
+    return df
+
+
+def main() -> None:
+    args = parse_args()
+    configure_logging(args.log_level)
+    inp = Path(args.input)
+    out = Path(args.output)
+    df = read_target_names(inp, column=args.column)
+    df = normalize_dataframe(df, args.column)
+    write_with_new_columns(df, out)
+
+
+if __name__ == "__main__":
+    main()

--- a/mylib/__init__.py
+++ b/mylib/__init__.py
@@ -1,0 +1,6 @@
+"""Utility package for target name normalization."""
+
+from .io_utils import read_target_names, write_with_new_columns
+from .transforms import normalize_target_name
+
+__all__ = ["read_target_names", "write_with_new_columns", "normalize_target_name"]

--- a/mylib/io_utils.py
+++ b/mylib/io_utils.py
@@ -1,0 +1,122 @@
+"""I/O utilities for target normalization.
+
+This module contains functions for reading the source CSV with
+automatic encoding and delimiter detection, as well as helpers for
+loading external mapping dictionaries.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Tuple
+import csv
+import json
+
+import pandas as pd
+
+# Default encodings and delimiters to try when reading CSV files.
+ENCODINGS: Tuple[str, ...] = ("utf-8-sig", "cp1251", "latin1")
+DELIMITERS: Tuple[str, ...] = (",", ";", "\t", "|")
+
+
+def detect_csv_format(path: Path) -> Tuple[str, str]:
+    """Detect encoding and delimiter of a CSV file.
+
+    Parameters
+    ----------
+    path:
+        Path to the CSV file.
+
+    Returns
+    -------
+    Tuple[str, str]
+        Detected encoding and delimiter.
+
+    Raises
+    ------
+    ValueError
+        If the file format could not be detected.
+    """
+    for enc in ENCODINGS:
+        try:
+            with path.open("r", encoding=enc) as fh:
+                sample = fh.read(4096)
+                sniffer = csv.Sniffer()
+                try:
+                    dialect = sniffer.sniff(sample, delimiters="".join(DELIMITERS))
+                    return enc, dialect.delimiter
+                except csv.Error:
+                    first_line = sample.splitlines()[0]
+                    for delim in DELIMITERS:
+                        if delim in first_line:
+                            return enc, delim
+                    # fallback to comma when single column
+                    return enc, ","
+        except Exception:
+            continue
+    raise ValueError("Could not detect CSV encoding or delimiter")
+
+
+def read_target_names(path: Path, column: str = "target_name") -> pd.DataFrame:
+    """Read the CSV and return DataFrame with target names.
+
+    Parameters
+    ----------
+    path:
+        Path to the input CSV file.
+    column:
+        Name of the column containing target names.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame containing at least the raw column.
+    """
+    enc, delim = detect_csv_format(path)
+    df = pd.read_csv(path, encoding=enc, sep=delim)
+    if column not in df.columns:
+        raise KeyError(f"Column '{column}' not found in {path}")
+    return df
+
+
+def write_with_new_columns(
+    df: pd.DataFrame, path: Path, encoding: str = "utf-8"
+) -> None:
+    """Write DataFrame to CSV with given encoding.
+
+    Parameters
+    ----------
+    df:
+        DataFrame to save.
+    path:
+        Output path.
+    encoding:
+        Target encoding, default UTF-8.
+    """
+    df.to_csv(path, index=False, encoding=encoding)
+
+
+def load_mapping(path: Path) -> Dict[str, str]:
+    """Load mapping dictionary from JSON or TSV.
+
+    Parameters
+    ----------
+    path:
+        Path to JSON or TSV file.
+
+    Returns
+    -------
+    dict
+        Mapping loaded from file.
+    """
+    if path.suffix.lower() == ".json":
+        with path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    if path.suffix.lower() in {".tsv", ".txt"}:
+        mapping: Dict[str, str] = {}
+        with path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                key, val = line.rstrip().split("\t", 1)
+                mapping[key] = val
+        return mapping
+    raise ValueError(f"Unsupported mapping format: {path.suffix}")

--- a/mylib/transforms.py
+++ b/mylib/transforms.py
@@ -1,0 +1,275 @@
+"""Text normalization transformations for protein target names."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+import re
+import unicodedata
+from typing import Dict, List, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Default dictionaries -----------------------------------------------------
+
+GREEK_LETTERS: Dict[str, str] = {
+    "α": "alpha",
+    "β": "beta",
+    "γ": "gamma",
+    "δ": "delta",
+    "ε": "epsilon",
+    "ζ": "zeta",
+    "η": "eta",
+    "θ": "theta",
+    "ι": "iota",
+    "κ": "kappa",
+    "λ": "lambda",
+    "μ": "mu",
+    "ν": "nu",
+    "ξ": "xi",
+    "ο": "omicron",
+    "π": "pi",
+    "ρ": "rho",
+    "σ": "sigma",
+    "τ": "tau",
+    "υ": "upsilon",
+    "φ": "phi",
+    "χ": "chi",
+    "ψ": "psi",
+    "ω": "omega",
+}
+
+SUPERSCRIPTS: Dict[str, str] = {
+    "¹": "1",
+    "²": "2",
+    "³": "3",
+    "⁴": "4",
+    "⁵": "5",
+    "⁶": "6",
+    "⁷": "7",
+    "⁸": "8",
+    "⁹": "9",
+    "⁰": "0",
+    "₁": "1",
+    "₂": "2",
+    "₃": "3",
+    "₄": "4",
+    "₅": "5",
+    "₆": "6",
+    "₇": "7",
+    "₈": "8",
+    "₉": "9",
+    "₀": "0",
+}
+
+STOP_WORDS: Sequence[str] = (
+    "protein",
+    "receptor",
+    "isoform",
+    "fragment",
+    "subunit",
+    "chain",
+    "precursor",
+    "like",
+    "putative",
+    "probable",
+    "predicted",
+    "family",
+)
+
+RECEPTOR_RULES: Sequence[Tuple[re.Pattern[str], str, str]] = (
+    # pattern, replacement, gene-like candidate
+    (re.compile(r"beta2\s+adrenergic\s+receptor"), "beta2 adrenergic", "adrb2"),
+    (re.compile(r"dopamine\s+d2\s+receptor"), "dopamine d2", "drd2"),
+    (re.compile(r"serotonin\s+5-ht1a\s+receptor"), "5-ht1a serotonin", "htr1a"),
+    (re.compile(r"histamine\s+h3\s+receptor"), "histamine h3", "hrh3"),
+)
+
+CANDIDATE_PREFIXES: Dict[str, str] = {
+    "h3": "hrh3",
+    "d2": "drd2",
+    "beta2": "adrb2",
+    "5-ht1a": "htr1a",
+}
+
+ROMAN_NUMERALS: Dict[str, str] = {"ii": "2", "iii": "3", "iv": "4"}
+
+CONTROL_CHARS_RE = re.compile(r"[\u0000-\u001F\u007F]")
+MULTI_SPACE_RE = re.compile(r"[\s\t]+")
+TYPO_QUOTES_RE = re.compile(r"[“”«»„]|’")
+LONG_DASH_RE = re.compile(r"[–—]")
+PAREN_RE = re.compile(r"\(([^(]*)\)|\[([^\]]*)\]|\{([^}]*)\)")
+TOKEN_SPLIT_RE = re.compile(r"[\s\-_/,:;\.]+")
+LETTER_NUM_SPACE_RE = re.compile(r"(?<=\b)([a-z])\s+([0-9])(?=\b)", re.I)
+NUM_LETTER_SPACE_RE = re.compile(r"(?<=\b)([0-9])\s+([a-z])(?=\b)", re.I)
+HYPHEN_SPACE_RE = re.compile(r"\s*-\s*")
+
+
+def sanitize_text(text: str) -> str:
+    """Remove control characters and normalize whitespace."""
+    text = CONTROL_CHARS_RE.sub("", text)
+    text = text.replace("\ufeff", "").replace("\xa0", " ")
+    text = MULTI_SPACE_RE.sub(" ", text)
+    return text.strip()
+
+
+def normalize_unicode(text: str) -> str:
+    """Apply Unicode NFKC normalization and lowercase."""
+    text = unicodedata.normalize("NFKC", text)
+    text = text.lower()
+    text = TYPO_QUOTES_RE.sub("'", text)
+    text = LONG_DASH_RE.sub("-", text)
+    return text
+
+
+def replace_specials(
+    text: str,
+    greek: Dict[str, str] | None = None,
+    superscripts: Dict[str, str] | None = None,
+) -> str:
+    """Replace greek letters and superscripts using mappings."""
+    greek = greek or GREEK_LETTERS
+    superscripts = superscripts or SUPERSCRIPTS
+    for k, v in greek.items():
+        text = text.replace(k, v)
+    for k, v in superscripts.items():
+        text = text.replace(k, v)
+    return text
+
+
+def replace_roman_numerals(text: str) -> str:
+    """Replace standalone Roman numerals with digits."""
+
+    def repl(match: re.Match[str]) -> str:
+        token = match.group(0)
+        return ROMAN_NUMERALS[token]
+
+    pattern = re.compile(r"\b(ii|iii|iv)\b")
+    return pattern.sub(repl, text)
+
+
+def extract_parenthetical(text: str) -> Tuple[str, List[str]]:
+    """Extract text within brackets into a hint field."""
+    hints: List[str] = []
+
+    def repl(match: re.Match[str]) -> str:
+        # match groups correspond to (), [], {}
+        for group in match.groups():
+            if group:
+                hints.append(group.strip())
+        return ""
+
+    text = PAREN_RE.sub(repl, text)
+    return text, hints
+
+
+def pretoken_cleanup(text: str) -> str:
+    """Glue separated tokens before splitting."""
+    text = LETTER_NUM_SPACE_RE.sub(r"\1\2", text)
+    text = NUM_LETTER_SPACE_RE.sub(r"\1\2", text)
+    text = HYPHEN_SPACE_RE.sub("-", text)
+    return text
+
+
+def tokenize(text: str) -> List[str]:
+    """Split text into tokens using configured delimiters."""
+    return [t for t in TOKEN_SPLIT_RE.split(text) if t]
+
+
+def remove_weak_words(tokens: Sequence[str]) -> Tuple[List[str], List[str]]:
+    """Remove weak/stop words from token list."""
+    dropped: List[str] = []
+    result: List[str] = []
+    for tok in tokens:
+        if tok in STOP_WORDS:
+            dropped.append(tok)
+        else:
+            result.append(tok)
+    return result, dropped
+
+
+def apply_receptor_rules(text: str) -> Tuple[str, List[str], List[str]]:
+    """Apply receptor family normalization rules.
+
+    Returns
+    -------
+    Tuple of (new_text, gene_like_candidates, rules_applied)
+    """
+    candidates: List[str] = []
+    applied: List[str] = []
+    for pattern, replacement, candidate in RECEPTOR_RULES:
+        if pattern.search(text):
+            text = pattern.sub(replacement, text)
+            candidates.append(candidate)
+            applied.append(pattern.pattern)
+    return text, candidates, applied
+
+
+def generate_candidates(tokens: Sequence[str]) -> List[str]:
+    """Generate gene-like candidates from tokens."""
+    candidates: List[str] = []
+    for tok in tokens:
+        if tok in CANDIDATE_PREFIXES:
+            candidates.append(CANDIDATE_PREFIXES[tok])
+    return candidates
+
+
+def final_cleanup(tokens: Sequence[str]) -> List[str]:
+    """Remove duplicate tokens while preserving order."""
+    seen = set()
+    result: List[str] = []
+    for tok in tokens:
+        if tok not in seen:
+            seen.add(tok)
+            result.append(tok)
+    return result
+
+
+@dataclass
+class NormalizationResult:
+    raw: str
+    clean_text: str
+    query_tokens: List[str]
+    gene_like_candidates: List[str]
+    hint_taxon: int
+    hints: Dict[str, List[str]]
+    rules_applied: List[str]
+
+
+def normalize_target_name(name: str) -> NormalizationResult:
+    """Normalize a single target name.
+
+    Parameters
+    ----------
+    name:
+        Raw target name.
+
+    Returns
+    -------
+    NormalizationResult
+        Structured normalization information.
+    """
+    raw = name
+    stage = sanitize_text(name)
+    stage = normalize_unicode(stage)
+    stage = replace_specials(stage)
+    stage = replace_roman_numerals(stage)
+    stage, parenthetical = extract_parenthetical(stage)
+    stage = pretoken_cleanup(stage)
+    stage, rule_candidates, rules_applied = apply_receptor_rules(stage)
+    tokens = tokenize(stage)
+    tokens, dropped = remove_weak_words(tokens)
+    candidates = generate_candidates(tokens)
+    candidates.extend(rule_candidates)
+    tokens = final_cleanup(tokens)
+    clean_text = " ".join(tokens)
+    hints = {"parenthetical": parenthetical, "dropped": dropped}
+    return NormalizationResult(
+        raw=raw,
+        clean_text=clean_text,
+        query_tokens=tokens,
+        gene_like_candidates=final_cleanup(candidates),
+        hint_taxon=9606,
+        hints=hints,
+        rules_applied=rules_applied,
+    )

--- a/mylib/validate.py
+++ b/mylib/validate.py
@@ -1,0 +1,17 @@
+"""Validation helpers for target normalization."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def ensure_column(df: pd.DataFrame, column: str) -> None:
+    """Ensure DataFrame has required column.
+
+    Raises
+    ------
+    KeyError
+        If column is missing.
+    """
+    if column not in df.columns:
+        raise KeyError(f"Column '{column}' is required")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas>=2.0
+pytest>=7.0

--- a/tests/data/sample.csv
+++ b/tests/data/sample.csv
@@ -1,0 +1,5 @@
+target_name
+"β2-adrenergic receptor"
+"histamine h3 receptor (isoform)"
+"dopamine d2 receptor"
+"serotonin 5-ht1a receptor"

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from mylib.io_utils import read_target_names
+from mylib.transforms import (
+    apply_receptor_rules,
+    normalize_target_name,
+    replace_specials,
+    sanitize_text,
+)
+
+
+def test_sanitize_and_replace():
+    text = "\u0000β receptor"
+    clean = sanitize_text(text)
+    clean = replace_specials(clean)
+    assert clean == "beta receptor"
+
+
+def test_receptor_rules():
+    text = "dopamine d2 receptor"
+    new_text, candidates, rules = apply_receptor_rules(text)
+    assert new_text == "dopamine d2"
+    assert "drd2" in candidates
+    assert rules
+
+
+def test_full_normalization():
+    sample = Path("tests/data/sample.csv")
+    df = read_target_names(sample)
+    result = normalize_target_name(df.loc[0, "target_name"])
+    assert result.clean_text.startswith("beta2 adrenergic")
+    assert "adrb2" in result.gene_like_candidates


### PR DESCRIPTION
## Summary
- implement modular pipeline for non-destructive normalization of target names
- add CLI script with logging and CSV I/O utilities
- include unit tests, sample data, and development instructions

## Testing
- `ruff check .`
- `black --check .`
- `mypy . --ignore-missing-imports`
- `pytest`
- `python main.py --input tests/data/sample.csv --output tests/data/out.csv`


------
https://chatgpt.com/codex/tasks/task_e_68b703f462a083249dbb3b05a40cfc4f