### PR TITLE
Add target name normalization module and CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+*.log
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# Target Name Normalization
+
+Utilities for heavy but non-destructive normalization of protein target names.
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Optional quality tools:
+
+```bash
+pip install black ruff mypy
+```
+
+## Usage
+
+```bash
+python main.py --input target_validation_new.csv --output normalized.csv
+```
+
+The output CSV includes columns:
+
+- `clean_text` – normalized name without stop words
+- `clean_text_alt` – version retaining stop words
+- `query_tokens`, `gene_like_candidates`, `hints`, `rules_applied`, `hint_taxon`
+
+`clean_text` and `clean_text_alt` collect all distinct textual variants
+(hyphenated/concatenated forms, retained bracket indices, etc.) joined with a
+pipe (`|`) only when more than one unique form exists. `query_tokens` uses the
+same separator for multiple tokens. `hints` and `rules_applied` are stored as
+JSON structures in the output CSV, preserving the original dictionaries and
+lists used during processing.
+
+
+Hyphenated tokens (e.g. `beta2-adrenergic`) and letter–digit pairs with spaces
+(`h 3`) emit both dashed and undashed variants in `clean_text` and
+`query_tokens` (`beta2-adrenergic`/`beta2adrenergic`, `h-3`/`h3`) to aid
+downstream matching. Original split tokens (e.g. `h` and `3`) are also
+preserved in `query_tokens`.
+
+Short indices enclosed in brackets such as `h3`, `p2x7`, or `5-ht1a` are
+kept; the bracketed content is stored under `hints.parenthetical`.
+
+Mutation-like substrings (`V600E`, `p.Gly12Asp`, `ΔF508`, etc.) are detected
+via regex rules, removed from the normalized tokens, and recorded under
+`hints.mutations`. If removing mutations leaves no core tokens, the original
+tokens are restored and `hints.mutations_only` is set to `true`.
+
+Gene-like candidates are inferred via regex rules:
+
+- `histamine h3` → `hrh3`
+- `dopamine d2` → `drd2`
+- `adrenergic beta1` → `adrb1`
+- `p2x3` → `p2rx3`
+- `5-ht1a` → `htr1a`
+- `gaba a alpha2` → `gabra2`
+
+## Development
+
+Run formatting and tests:
+
+```bash
+ruff check .
+black --check .
+pytest
+mypy .
+```

--- a/main.py
+++ b/main.py
@@ -1,0 +1,55 @@
+"""CLI entry point for target name normalization."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import List
+
+import pandas as pd
+
+from mylib.io_utils import read_target_names, write_with_new_columns
+from mylib.transforms import NormalizationResult, normalize_target_name
+
+
+def configure_logging(level: str) -> None:
+    logging.basicConfig(level=getattr(logging, level.upper(), logging.INFO))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Normalize target names")
+    parser.add_argument("--input", required=True, help="Path to input CSV")
+    parser.add_argument("--output", required=True, help="Path to output CSV")
+    parser.add_argument("--column", default="target_name", help="Name column")
+    parser.add_argument("--log-level", default="INFO", help="Logging level")
+    return parser.parse_args()
+
+
+def normalize_dataframe(df: pd.DataFrame, column: str) -> pd.DataFrame:
+    results: List[NormalizationResult] = [
+        normalize_target_name(str(val)) for val in df[column]
+    ]
+    df = df.copy()
+    df["clean_text"] = [r.clean_text for r in results]
+    df["clean_text_alt"] = [r.clean_text_alt for r in results]
+    df["query_tokens"] = ["|".join(r.query_tokens) for r in results]
+    df["gene_like_candidates"] = [" ".join(r.gene_like_candidates) for r in results]
+    df["hints"] = [r.hints for r in results]
+    df["rules_applied"] = [r.rules_applied for r in results]
+    df["hint_taxon"] = [r.hint_taxon for r in results]
+    return df
+
+
+def main() -> None:
+    args = parse_args()
+    configure_logging(args.log_level)
+    inp = Path(args.input)
+    out = Path(args.output)
+    df = read_target_names(inp, column=args.column)
+    df = normalize_dataframe(df, args.column)
+    write_with_new_columns(df, out)
+
+
+if __name__ == "__main__":
+    main()

--- a/mylib/__init__.py
+++ b/mylib/__init__.py
@@ -1,0 +1,6 @@
+"""Utility package for target name normalization."""
+
+from .io_utils import read_target_names, write_with_new_columns
+from .transforms import normalize_target_name
+
+__all__ = ["read_target_names", "write_with_new_columns", "normalize_target_name"]

--- a/mylib/io_utils.py
+++ b/mylib/io_utils.py
@@ -1,0 +1,126 @@
+"""I/O utilities for target normalization.
+
+This module contains functions for reading the source CSV with
+automatic encoding and delimiter detection, as well as helpers for
+loading external mapping dictionaries.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Tuple
+import csv
+import json
+
+import pandas as pd
+
+# Default encodings and delimiters to try when reading CSV files.
+ENCODINGS: Tuple[str, ...] = ("utf-8-sig", "cp1251", "latin1")
+DELIMITERS: Tuple[str, ...] = (",", ";", "\t", "|")
+
+
+def detect_csv_format(path: Path) -> Tuple[str, str]:
+    """Detect encoding and delimiter of a CSV file.
+
+    Parameters
+    ----------
+    path:
+        Path to the CSV file.
+
+    Returns
+    -------
+    Tuple[str, str]
+        Detected encoding and delimiter.
+
+    Raises
+    ------
+    ValueError
+        If the file format could not be detected.
+    """
+    for enc in ENCODINGS:
+        try:
+            with path.open("r", encoding=enc) as fh:
+                sample = fh.read(4096)
+                sniffer = csv.Sniffer()
+                try:
+                    dialect = sniffer.sniff(sample, delimiters="".join(DELIMITERS))
+                    return enc, dialect.delimiter
+                except csv.Error:
+                    first_line = sample.splitlines()[0]
+                    for delim in DELIMITERS:
+                        if delim in first_line:
+                            return enc, delim
+                    # fallback to comma when single column
+                    return enc, ","
+        except Exception:
+            continue
+    raise ValueError("Could not detect CSV encoding or delimiter")
+
+
+def read_target_names(path: Path, column: str = "target_name") -> pd.DataFrame:
+    """Read the CSV and return DataFrame with target names.
+
+    Parameters
+    ----------
+    path:
+        Path to the input CSV file.
+    column:
+        Name of the column containing target names.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame containing at least the raw column.
+    """
+    enc, delim = detect_csv_format(path)
+    df = pd.read_csv(path, encoding=enc, sep=delim)
+    if column not in df.columns:
+        raise KeyError(f"Column '{column}' not found in {path}")
+    return df
+
+
+def write_with_new_columns(
+    df: pd.DataFrame, path: Path, encoding: str = "utf-8"
+) -> None:
+    """Write DataFrame to CSV with given encoding.
+
+    Parameters
+    ----------
+    df:
+        DataFrame to save.
+    path:
+        Output path.
+    encoding:
+        Target encoding, default UTF-8.
+    """
+    df = df.copy()
+    for col in ("hints", "rules_applied"):
+        if col in df.columns:
+            df[col] = df[col].apply(lambda x: json.dumps(x, ensure_ascii=False))
+    df.to_csv(path, index=False, encoding=encoding)
+
+
+def load_mapping(path: Path) -> Dict[str, str]:
+    """Load mapping dictionary from JSON or TSV.
+
+    Parameters
+    ----------
+    path:
+        Path to JSON or TSV file.
+
+    Returns
+    -------
+    dict
+        Mapping loaded from file.
+    """
+    if path.suffix.lower() == ".json":
+        with path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    if path.suffix.lower() in {".tsv", ".txt"}:
+        mapping: Dict[str, str] = {}
+        with path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                key, val = line.rstrip().split("\t", 1)
+                mapping[key] = val
+        return mapping
+    raise ValueError(f"Unsupported mapping format: {path.suffix}")

--- a/mylib/transforms.py
+++ b/mylib/transforms.py
@@ -1,0 +1,556 @@
+"""Text normalization transformations for protein target names."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+import re
+import unicodedata
+from typing import Dict, List, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Default dictionaries -----------------------------------------------------
+
+GREEK_LETTERS: Dict[str, str] = {
+    "α": "alpha",
+    "β": "beta",
+    "γ": "gamma",
+    "δ": "delta",
+    "ε": "epsilon",
+    "ζ": "zeta",
+    "η": "eta",
+    "θ": "theta",
+    "ι": "iota",
+    "κ": "kappa",
+    "λ": "lambda",
+    "μ": "mu",
+    "ν": "nu",
+    "ξ": "xi",
+    "ο": "omicron",
+    "π": "pi",
+    "ρ": "rho",
+    "σ": "sigma",
+    "τ": "tau",
+    "υ": "upsilon",
+    "φ": "phi",
+    "χ": "chi",
+    "ψ": "psi",
+    "ω": "omega",
+}
+
+SUPERSCRIPTS: Dict[str, str] = {
+    "¹": "1",
+    "²": "2",
+    "³": "3",
+    "⁴": "4",
+    "⁵": "5",
+    "⁶": "6",
+    "⁷": "7",
+    "⁸": "8",
+    "⁹": "9",
+    "⁰": "0",
+    "₁": "1",
+    "₂": "2",
+    "₃": "3",
+    "₄": "4",
+    "₅": "5",
+    "₆": "6",
+    "₇": "7",
+    "₈": "8",
+    "₉": "9",
+    "₀": "0",
+}
+
+STOP_WORDS: Sequence[str] = (
+    "protein",
+    "receptor",
+    "channel",
+    "isoform",
+    "fragment",
+    "subunit",
+    "chain",
+    "precursor",
+    "like",
+    "putative",
+    "probable",
+    "predicted",
+    "family",
+)
+
+RECEPTOR_RULES: Sequence[Tuple[re.Pattern[str], str, str]] = (
+    # pattern, replacement, gene-like candidate
+    (re.compile(r"beta2\s+adrenergic\s+receptor"), "beta2 adrenergic", "adrb2"),
+    (re.compile(r"dopamine\s+d2\s+receptor"), "dopamine d2", "drd2"),
+    (re.compile(r"serotonin\s+5-ht1a\s+receptor"), "5-ht1a serotonin", "htr1a"),
+    (re.compile(r"histamine\s+h3\s+receptor"), "histamine h3", "hrh3"),
+)
+
+CANDIDATE_REGEX_RULES: Sequence[Tuple[re.Pattern[str], str]] = (
+    (re.compile(r"histamine\s+h(\d+)"), r"hrh\1"),
+    (re.compile(r"dopamine\s+d(\d+)"), r"drd\1"),
+    (re.compile(r"adrenergic\s+beta(\d+)"), r"adrb\1"),
+    (re.compile(r"p2x(\d+)"), r"p2rx\1"),
+    (re.compile(r"5[- ]?ht(\d+[a-z]?)"), r"htr\1"),
+    (re.compile(r"gaba\s+a\s+alpha(\d+)"), r"gabra\1"),
+)
+
+ROMAN_NUMERALS: Dict[str, str] = {"ii": "2", "iii": "3", "iv": "4"}
+
+CONTROL_CHARS_RE = re.compile(r"[\u0000-\u001F\u007F]")
+MULTI_SPACE_RE = re.compile(r"[\s\t]+")
+TYPO_QUOTES_RE = re.compile(r"[“”«»„]|’")
+LONG_DASH_RE = re.compile(r"[–—]")
+PAREN_RE = re.compile(r"\(([^(]*)\)|\[([^\]]*)\]|\{([^}]*)\)")
+TOKEN_SPLIT_RE = re.compile(r"[\s\-_/,:;\.]+")
+HYPHEN_SPACE_RE = re.compile(r"\s*-\s*")
+HYPHEN_TOKEN_RE = re.compile(r"\b[a-z0-9]+(?:-[a-z0-9]+)+\b")
+SHORT_TOKEN_RE = re.compile(r"^[a-z0-9]{1,3}$")
+INDEX_TOKEN_RE = re.compile(r"^(?:[a-z]\d(?:[a-z]\d+)?|5-?ht\d+[a-z]?)$")
+LETTER_DIGIT_SPLIT_RE = re.compile(r"\b(?:[a-z]\s+\d+|\d+\s+[a-z])\b")
+
+# Patterns for mutation extraction ------------------------------------------------
+MUTATION_PATTERNS: Sequence[re.Pattern[str]] = (
+    re.compile(r"p\.[A-Z][0-9]+[A-Z]", re.IGNORECASE),
+    re.compile(r"p\.[A-Z][0-9]+(?:\*|Ter)", re.IGNORECASE),
+    re.compile(r"p\.[A-Z][0-9]+(?:_[A-Z][0-9]+)?del", re.IGNORECASE),
+    re.compile(r"p\.[A-Z][0-9]+_[A-Z][0-9]+ins[A-Z]+", re.IGNORECASE),
+    re.compile(r"p\.[A-Z][0-9]+(?:_[A-Z][0-9]+)?dup", re.IGNORECASE),
+    re.compile(r"p\.[A-Z][0-9]+fs(?:\*[0-9]+)?", re.IGNORECASE),
+    re.compile(r"p\.Met1\?", re.IGNORECASE),
+    re.compile(r"p\.\*[0-9]+[A-Z]", re.IGNORECASE),
+    re.compile(r"p\.[A-Z][0-9]+(?:_[A-Z][0-9]+)?delins[A-Z]+", re.IGNORECASE),
+    re.compile(r"p\.[A-Z][a-z]{2}[0-9]+(?:[A-Z][a-z]{2}|\*|Ter)", re.IGNORECASE),
+    re.compile(r"\b[A-Z][0-9]+[A-Z]\b", re.IGNORECASE),
+    re.compile(
+        r"(?<!p\.)[A-Z][a-z]{2}[0-9]+(?:[A-Z][a-z]{2}|\*|Ter)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b[pcgnmr]\.[0-9]+[+-]?[0-9]*(?:_[+-]?[0-9]+)?(?:[ACGT]>[ACGT]|delins|del|ins|dup|inv|fs\*?[0-9]*)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\b(?:[A-Z][0-9]+[A-Z])(?:/[A-Z][0-9]+[A-Z])+\b", re.IGNORECASE),
+    re.compile(r"(?:Δ|delta)\s?[A-Z][0-9]+", re.IGNORECASE),
+    re.compile(r"\b(mutant|variant|mut\.)\b", re.IGNORECASE),
+)
+
+MUTATION_WHITELIST = {
+    "m2",
+    "h3",
+    "d2",
+    "p2x7",
+    "p2x",
+    "5-ht1a",
+    "alpha1",
+    "beta2",
+}
+
+
+def sanitize_text(text: str) -> str:
+    """Remove control characters and normalize whitespace."""
+    text = CONTROL_CHARS_RE.sub("", text)
+    text = text.replace("\ufeff", "").replace("\xa0", " ")
+    text = MULTI_SPACE_RE.sub(" ", text)
+    return text.strip()
+
+
+def normalize_unicode(text: str) -> str:
+    """Apply Unicode NFKC normalization and lowercase."""
+    text = unicodedata.normalize("NFKC", text)
+    text = text.lower()
+    text = TYPO_QUOTES_RE.sub("'", text)
+    text = LONG_DASH_RE.sub("-", text)
+    return text
+
+
+def replace_specials(
+    text: str,
+    greek: Dict[str, str] | None = None,
+    superscripts: Dict[str, str] | None = None,
+) -> str:
+    """Replace greek letters and superscripts using mappings."""
+    greek = greek or GREEK_LETTERS
+    superscripts = superscripts or SUPERSCRIPTS
+    for k, v in greek.items():
+        text = text.replace(k, v)
+    for k, v in superscripts.items():
+        text = text.replace(k, v)
+    return text
+
+
+def replace_roman_numerals(text: str) -> str:
+    """Replace standalone Roman numerals with digits."""
+
+    def repl(match: re.Match[str]) -> str:
+        token = match.group(0)
+        return ROMAN_NUMERALS[token]
+
+    pattern = re.compile(r"\b(ii|iii|iv)\b")
+    return pattern.sub(repl, text)
+
+
+def extract_parenthetical(text: str) -> Tuple[str, List[str], List[str]]:
+    """Extract bracketed text into hints and retain certain short tokens.
+
+    Parameters
+    ----------
+    text:
+        Input string with possible parenthetical segments.
+
+    Returns
+    -------
+    Tuple[str, List[str], List[str]]
+        The text with brackets removed, list of extracted strings for hints,
+        and tokens that should remain in the main text.
+    """
+
+    hints: List[str] = []
+    keep_tokens: List[str] = []
+
+    def repl(match: re.Match[str]) -> str:
+        for group in match.groups():
+            if not group:
+                continue
+            token = group.strip()
+            hints.append(token)
+            compact = re.sub(r"[\s_\-]", "", token)
+            if SHORT_TOKEN_RE.fullmatch(compact) or INDEX_TOKEN_RE.fullmatch(compact):
+                keep_tokens.append(token.strip())
+        return ""
+
+    text = PAREN_RE.sub(repl, text)
+    return text, hints, keep_tokens
+
+
+def pretoken_cleanup(text: str) -> str:
+    """Normalize spaces around hyphens before splitting."""
+    text = HYPHEN_SPACE_RE.sub("-", text)
+    return text
+
+
+def generate_letter_digit_variants(tokens: Sequence[str]) -> List[Tuple[str, str]]:
+    """Create joined variants for adjacent letter-digit tokens.
+
+    Parameters
+    ----------
+    tokens:
+        Tokens obtained after initial splitting.
+
+    Returns
+    -------
+    List[Tuple[str, str]]
+        Pairs of (variant, base_pattern) where ``base_pattern`` is the
+        space-separated form in the original text.
+    """
+
+    variants: List[Tuple[str, str]] = []
+    for i in range(len(tokens) - 1):
+        left, right = tokens[i], tokens[i + 1]
+        if left.isalpha() and right.isdigit():
+            base = f"{left} {right}"
+            variants.append((f"{left}{right}", base))
+            variants.append((f"{left}-{right}", base))
+    return variants
+
+
+def detect_hyphen_variants(text: str) -> List[Tuple[str, str]]:
+    """Return hyphenated tokens and their space-separated base pattern.
+
+    Each result is a pair of (variant, base_pattern). Variants include the
+    original hyphenated token and its concatenated counterpart.
+    """
+
+    variants: List[Tuple[str, str]] = []
+    for token in HYPHEN_TOKEN_RE.findall(text):
+        base = token.replace("-", " ")
+        variants.append((token, base))
+        variants.append((token.replace("-", ""), base))
+    return variants
+
+
+def build_variant_strings(
+    base: str,
+    substitutions: Sequence[Tuple[str, str]],
+    extra: Sequence[str] | None = None,
+) -> List[str]:
+    """Generate variant strings from a base text and substitution patterns.
+
+    Parameters
+    ----------
+    base:
+        Base string joined from primary tokens.
+    substitutions:
+        Sequence of ``(variant, base_pattern)`` tuples used to replace parts of
+        the base string.
+    extra:
+        Additional standalone tokens to include as separate variants.
+
+    Returns
+    -------
+    List[str]
+        Unique variant strings with empty values removed.
+    """
+
+    variants: List[str] = []
+    base = base.strip()
+    if base and not LETTER_DIGIT_SPLIT_RE.search(base):
+        variants.append(base)
+    for var, pattern in substitutions:
+        if base and pattern in base:
+            variants.append(base.replace(pattern, var))
+        variants.append(var)
+    if extra:
+        variants.extend(extra)
+    seen: List[str] = []
+    for v in variants:
+        v = v.strip()
+        if v and v not in seen:
+            seen.append(v)
+    return seen
+
+
+def tokenize(text: str) -> List[str]:
+    """Split text into tokens using configured delimiters."""
+    return [t for t in TOKEN_SPLIT_RE.split(text) if t]
+
+
+def remove_weak_words(tokens: Sequence[str]) -> Tuple[List[str], List[str]]:
+    """Remove weak/stop words from token list."""
+    dropped: List[str] = []
+    result: List[str] = []
+    for tok in tokens:
+        if tok in STOP_WORDS:
+            dropped.append(tok)
+        else:
+            result.append(tok)
+    return result, dropped
+
+
+def find_mutations(text: str) -> List[str]:
+    """Extract mutation-like substrings from text.
+
+    Parameters
+    ----------
+    text:
+        Input string in its original form.
+
+    Returns
+    -------
+    List[str]
+        Unique mutation substrings in order of appearance.
+    """
+
+    found: List[str] = []
+    for pattern in MUTATION_PATTERNS:
+        for match in pattern.finditer(text):
+            token = match.group(0)
+            lower = token.lower()
+            if lower in MUTATION_WHITELIST:
+                continue
+            if any(lower in f.lower() for f in found):
+                continue
+            found = [f for f in found if f.lower() not in lower]
+            if token not in found:
+                found.append(token)
+    return found
+
+
+def mutation_token_set(mutations: Sequence[str]) -> set[str]:
+    """Normalize and tokenize mutation strings for removal.
+
+    Parameters
+    ----------
+    mutations:
+        Mutation substrings captured from the raw text.
+
+    Returns
+    -------
+    set[str]
+        Lowercase tokens representing mutations to exclude from results.
+    """
+
+    tokens: set[str] = set()
+    for mut in mutations:
+        norm = normalize_unicode(mut)
+        norm = replace_specials(norm)
+        norm = replace_roman_numerals(norm)
+        norm_tokens = tokenize(norm)
+        for tok in norm_tokens:
+            tokens.add(tok)
+    return tokens
+
+
+def apply_receptor_rules(text: str) -> Tuple[str, List[str], List[str]]:
+    """Apply receptor family normalization rules.
+
+    Returns
+    -------
+    Tuple of (new_text, gene_like_candidates, rules_applied)
+    """
+    candidates: List[str] = []
+    applied: List[str] = []
+    for pattern, replacement, candidate in RECEPTOR_RULES:
+        if pattern.search(text):
+            text = pattern.sub(replacement, text)
+            candidates.append(candidate)
+            applied.append(pattern.pattern)
+    return text, candidates, applied
+
+
+def generate_regex_candidates(text: str) -> List[str]:
+    """Generate gene-like candidates from regex rules.
+
+    Parameters
+    ----------
+    text:
+        Concatenated normalized tokens.
+
+    Returns
+    -------
+    List[str]
+        Candidate gene symbols inferred from the text.
+    """
+
+    candidates: List[str] = []
+    for pattern, repl in CANDIDATE_REGEX_RULES:
+        for match in pattern.finditer(text):
+            candidate = match.expand(repl)
+            if candidate not in candidates:
+                candidates.append(candidate)
+    return candidates
+
+
+def final_cleanup(tokens: Sequence[str]) -> List[str]:
+    """Remove duplicate tokens while preserving order."""
+    seen = set()
+    result: List[str] = []
+    for tok in tokens:
+        if tok not in seen:
+            seen.add(tok)
+            result.append(tok)
+    return result
+
+
+@dataclass
+class NormalizationResult:
+    raw: str
+    clean_text: str
+    clean_text_alt: str
+    query_tokens: List[str]
+    gene_like_candidates: List[str]
+    hint_taxon: int
+    hints: Dict[str, List[str] | bool]
+    rules_applied: List[str]
+
+
+def normalize_target_name(name: str) -> NormalizationResult:
+    """Normalize a single target name.
+
+    Parameters
+    ----------
+    name:
+        Raw target name.
+
+    Returns
+    -------
+    NormalizationResult
+        Structured normalization information.
+    """
+    raw = name
+    stage = sanitize_text(name)
+    mutations = find_mutations(stage)
+    stage = normalize_unicode(stage)
+    stage = replace_specials(stage)
+    stage = replace_roman_numerals(stage)
+    stage, parenthetical, paren_tokens = extract_parenthetical(stage)
+    if paren_tokens:
+        stage = f"{stage} {' '.join(paren_tokens)}".strip()
+    stage = pretoken_cleanup(stage)
+    stage, rule_candidates, rules_applied = apply_receptor_rules(stage)
+    hyphen_subs = detect_hyphen_variants(stage)
+    tokens_base = tokenize(stage)
+    letter_digit_subs = generate_letter_digit_variants(tokens_base)
+    substitutions = hyphen_subs + letter_digit_subs
+    tokens_base_no_stop, dropped = remove_weak_words(tokens_base)
+    tokens_base_alt = final_cleanup(tokens_base)
+    tokens_no_stop = tokens_base_no_stop + [v for v, _ in substitutions]
+    tokens_alt = tokens_base_alt + [v for v, _ in substitutions]
+
+    mutation_tokens = mutation_token_set(mutations)
+    tokens_no_stop_orig = list(tokens_no_stop)
+    tokens_alt_orig = list(tokens_alt)
+    tokens_base_no_stop_orig = list(tokens_base_no_stop)
+    tokens_base_alt_orig = list(tokens_base_alt)
+
+    tokens_no_stop = [
+        t for t in tokens_no_stop if t not in mutation_tokens or t in MUTATION_WHITELIST
+    ]
+    tokens_alt = [
+        t for t in tokens_alt if t not in mutation_tokens or t in MUTATION_WHITELIST
+    ]
+    tokens_base_no_stop = [
+        t
+        for t in tokens_base_no_stop
+        if t not in mutation_tokens or t in MUTATION_WHITELIST
+    ]
+    tokens_base_alt = [
+        t
+        for t in tokens_base_alt
+        if t not in mutation_tokens or t in MUTATION_WHITELIST
+    ]
+
+    clean_tokens_check = [
+        t for t in tokens_no_stop if not re.fullmatch(r"[a-z]$|\d+$", t)
+    ]
+    hints_mutations_only = False
+    if not clean_tokens_check:
+        tokens_no_stop = tokens_no_stop_orig
+        tokens_alt = tokens_alt_orig
+        tokens_base_no_stop = tokens_base_no_stop_orig
+        tokens_base_alt = tokens_base_alt_orig
+        hints_mutations_only = True
+
+    tokens_no_stop = final_cleanup(tokens_no_stop)
+    tokens_alt = final_cleanup(tokens_alt)
+    base_no_stop_str = " ".join(tokens_base_no_stop)
+    base_alt_str = " ".join(tokens_base_alt)
+
+    clean_variants = build_variant_strings(
+        base_no_stop_str, substitutions, paren_tokens
+    )
+    clean_variants_alt = build_variant_strings(
+        base_alt_str, substitutions, paren_tokens
+    )
+
+    clean_text = (
+        "|".join(clean_variants)
+        if len(clean_variants) > 1
+        else (clean_variants[0] if clean_variants else "")
+    )
+    clean_text_alt = (
+        "|".join(clean_variants_alt)
+        if len(clean_variants_alt) > 1
+        else (clean_variants_alt[0] if clean_variants_alt else "")
+    )
+
+    text_for_candidates = " ".join(tokens_no_stop)
+    regex_candidates = generate_regex_candidates(text_for_candidates)
+    candidates = rule_candidates + regex_candidates
+    hints: Dict[str, List[str] | bool] = {
+        "parenthetical": parenthetical,
+        "dropped": dropped,
+        "mutations": mutations,
+    }
+    if hints_mutations_only:
+        hints["mutations_only"] = True
+    return NormalizationResult(
+        raw=raw,
+        clean_text=clean_text,
+        clean_text_alt=clean_text_alt,
+        query_tokens=tokens_no_stop,
+        gene_like_candidates=final_cleanup(candidates),
+        hint_taxon=9606,
+        hints=hints,
+        rules_applied=rules_applied,
+    )

--- a/mylib/validate.py
+++ b/mylib/validate.py
@@ -1,0 +1,17 @@
+"""Validation helpers for target normalization."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def ensure_column(df: pd.DataFrame, column: str) -> None:
+    """Ensure DataFrame has required column.
+
+    Raises
+    ------
+    KeyError
+        If column is missing.
+    """
+    if column not in df.columns:
+        raise KeyError(f"Column '{column}' is required")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas>=2.0
+pytest>=7.0

--- a/tests/data/sample.csv
+++ b/tests/data/sample.csv
@@ -1,0 +1,5 @@
+target_name
+"β2-adrenergic receptor"
+"histamine h3 receptor (isoform)"
+"dopamine d2 receptor"
+"serotonin 5-ht1a receptor"

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,0 +1,168 @@
+from pathlib import Path
+import sys
+import json
+
+import pandas as pd
+import pytest
+from typing import List, cast
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from main import normalize_dataframe
+from mylib.io_utils import read_target_names, write_with_new_columns
+from mylib.transforms import (
+    apply_receptor_rules,
+    normalize_target_name,
+    replace_specials,
+    sanitize_text,
+)
+
+
+def test_sanitize_and_replace():
+    text = "\u0000β receptor"
+    clean = sanitize_text(text)
+    clean = replace_specials(clean)
+    assert clean == "beta receptor"
+
+
+def test_receptor_rules():
+    text = "dopamine d2 receptor"
+    new_text, candidates, rules = apply_receptor_rules(text)
+    assert new_text == "dopamine d2"
+    assert "drd2" in candidates
+    assert rules
+
+
+def test_full_normalization():
+    sample = Path("tests/data/sample.csv")
+    df = read_target_names(sample)
+    result = normalize_target_name(df.loc[0, "target_name"])
+    assert result.clean_text.startswith("beta2 adrenergic")
+    assert result.clean_text_alt.startswith("beta2 adrenergic receptor")
+    assert "adrb2" in result.gene_like_candidates
+
+
+def test_parenthetical_short_token_retained():
+    result = normalize_target_name("histamine receptor (h3)")
+    assert "h3" in result.query_tokens
+    assert "histamine h3" in result.clean_text.split("|")
+    assert "h3" in result.clean_text.split("|")
+    assert result.hints["parenthetical"] == ["h3"]
+    assert "hrh3" in result.gene_like_candidates
+
+
+def test_clean_text_alt_retains_stopwords():
+    result = normalize_target_name("histamine receptor channel")
+    assert result.clean_text == "histamine"
+    assert result.clean_text_alt == "histamine receptor channel"
+    assert "receptor" in result.hints["dropped"]
+    assert "channel" in result.hints["dropped"]
+
+
+def test_hyphen_variants_present():
+    result = normalize_target_name("β2-adrenergic receptor")
+    assert "beta2-adrenergic" in result.query_tokens
+    assert "beta2adrenergic" in result.query_tokens
+    assert "beta2 adrenergic" in result.clean_text.split("|")
+    assert "beta2-adrenergic" in result.clean_text.split("|")
+    assert "beta2adrenergic" in result.clean_text.split("|")
+
+
+def test_letter_digit_space_variants():
+    result = normalize_target_name("h 3 receptor")
+    assert "h" in result.query_tokens
+    assert "3" in result.query_tokens
+    assert "h3" in result.query_tokens
+    assert "h-3" in result.query_tokens
+    assert result.clean_text.split("|") == ["h3", "h-3"]
+
+
+def test_parenthetical_complex_indices():
+    res1 = normalize_target_name("p2x receptor (p2x7)")
+    assert "p2x7" in res1.query_tokens
+    assert "p2x p2x7" in res1.clean_text.split("|")
+    assert "p2x7" in res1.clean_text.split("|")
+    assert res1.hints["parenthetical"] == ["p2x7"]
+
+    res2 = normalize_target_name("serotonin receptor (5-ht1a)")
+    assert "5-ht1a" in res2.query_tokens
+    assert "5ht1a" in res2.query_tokens
+    assert "serotonin 5-ht1a" in res2.clean_text.split("|")
+    assert "serotonin 5ht1a" in res2.clean_text.split("|")
+    assert "5-ht1a" in res2.clean_text.split("|")
+    assert "5ht1a" in res2.clean_text.split("|")
+    assert res2.hints["parenthetical"] == ["5-ht1a"]
+
+
+def test_dataframe_hints_and_rules(tmp_path: Path) -> None:
+    sample = Path("tests/data/sample.csv")
+    df = read_target_names(sample)
+    df_norm = normalize_dataframe(df, "target_name")
+    assert isinstance(df_norm.loc[0, "hints"], dict)
+    assert isinstance(df_norm.loc[0, "rules_applied"], list)
+    out = tmp_path / "out.csv"
+    write_with_new_columns(df_norm, out)
+    saved = pd.read_csv(out)
+    loaded_hints = json.loads(saved.loc[0, "hints"])
+    loaded_rules = json.loads(saved.loc[0, "rules_applied"])
+    assert isinstance(loaded_hints, dict)
+    assert isinstance(loaded_rules, list)
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("histamine h4", "hrh4"),
+        ("dopamine d3", "drd3"),
+        ("adrenergic beta1", "adrb1"),
+        ("p2x3", "p2rx3"),
+        ("5-ht1b", "htr1b"),
+        ("gaba a alpha2", "gabra2"),
+    ],
+)
+def test_regex_gene_like_candidates(name: str, expected: str) -> None:
+    result = normalize_target_name(name)
+    assert expected in result.gene_like_candidates
+
+
+def test_mutation_extraction_and_removal() -> None:
+    res = normalize_target_name("hiv1 protease I84V mutant")
+    assert res.clean_text == "hiv1 protease"
+    assert res.hints["mutations"] == ["I84V", "mutant"]
+
+    res = normalize_target_name("BRAF V600E")
+    assert res.clean_text == "braf"
+    assert res.hints["mutations"] == ["V600E"]
+
+    res = normalize_target_name("p.Gly12Asp KRAS")
+    assert res.clean_text == "kras"
+    assert res.hints["mutations"] == ["p.Gly12Asp"]
+
+    res = normalize_target_name("CFTR ΔF508")
+    assert res.clean_text == "cftr"
+    assert res.hints["mutations"] == ["ΔF508"]
+
+
+def test_mutation_whitelist() -> None:
+    res = normalize_target_name("muscarinic (m2) receptor")
+    assert "m2" in res.clean_text.split("|")
+    assert res.hints["mutations"] == []
+
+    text = (
+        "BRAF p.Q123* p.Q123Ter p.Q123_L125del p.T78_S79insA "
+        "p.A100dup p.R97fs*5 p.Met1? p.*100Y p.K45delinsST"
+    )
+    res = normalize_target_name(text)
+    assert res.clean_text == "braf"
+    mutations = cast(List[str], res.hints["mutations"])
+    assert set(mutations) == {
+        "p.Q123*",
+        "p.Q123Ter",
+        "p.Q123_L125del",
+        "p.T78_S79insA",
+        "p.A100dup",
+        "p.R97fs*5",
+        "p.Met1?",
+        "p.*100Y",
+        "p.K45delinsST",
+    }


### PR DESCRIPTION
## Summary
- implement modular pipeline for non-destructive normalization of target names
- add CLI script with logging and CSV I/O utilities
- include unit tests, sample data, and development instructions
- retain short parenthetical indices in normalized tokens and query tokens
- emit both split and joined variants for letter–digit pairs and hyphenated terms
- keep `hints` as dictionaries and `rules_applied` as lists, encoding them to JSON only on file export
- pipe-separate multiple variants in `clean_text`, `clean_text_alt`, and `query_tokens`
- strip mutation patterns from normalized tokens, recording them under `hints.mutations` and reverting when only mutations remain
- aggregate all spelling variants (with/without stop words, hyphenated forms, parenthetical indices) into deduplicated `clean_text` and `clean_text_alt`

## Testing
- `ruff check .`
- `black --check .`
- `mypy . --ignore-missing-imports`
- `pytest`
- `python main.py --input tests/data/sample.csv --output tests/data/out.csv`


------
https://chatgpt.com/codex/tasks/task_e_68b703f462a083249dbb3b05a40cfc4f