### PR TITLE
Improve CSV diagnostics and text normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,15 @@ preserved in `query_tokens`.
 Short indices enclosed in brackets such as `h3`, `p2x7`, or `5-ht1a` are
 kept; the bracketed content is stored under `hints.parenthetical`.
 
-Mutation-like substrings (`V600E`, `p.Gly12Asp`, `ΔF508`, etc.) are detected
-via regex rules, removed from the normalized tokens, and recorded under
-`hints.mutations`. If removing mutations leaves no core tokens, the original
-tokens are restored and `hints.mutations_only` is set to `true`.
+Mutation-like substrings (`V600E`, `p.Gly12Asp`, `ΔF508`, `F508del`, etc.) are
+detected via regex rules, with optional assistance from the `hgvs` parser when
+installed. By default these tokens are removed from the normalized output and
+recorded under `hints.mutations`. Use `--keep-mutations` to retain them. Tokens
+that resemble mutations but are valid receptor names are preserved through
+`MUTATION_WHITELIST`; additional tokens can be supplied with
+`--mutation-whitelist` (a text file with one token per line). If removing
+mutations leaves no core tokens, the original tokens are restored and
+`hints.mutations_only` is set to `true`.
 
 Gene-like candidates are inferred via regex rules:
 

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import logging
 from pathlib import Path
-from typing import List
+from typing import List, Sequence
 
 import pandas as pd
 
@@ -14,21 +14,44 @@ from mylib.transforms import NormalizationResult, normalize_target_name
 
 
 def configure_logging(level: str) -> None:
+    """Configure root logger."""
     logging.basicConfig(level=getattr(logging, level.upper(), logging.INFO))
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description="Normalize target names")
     parser.add_argument("--input", required=True, help="Path to input CSV")
     parser.add_argument("--output", required=True, help="Path to output CSV")
     parser.add_argument("--column", default="target_name", help="Name column")
     parser.add_argument("--log-level", default="INFO", help="Logging level")
+    parser.add_argument(
+        "--keep-mutations",
+        action="store_true",
+        help="Retain mutation-like tokens instead of stripping them",
+    )
+    parser.add_argument(
+        "--mutation-whitelist",
+        help="File with additional mutation tokens to preserve (one per line)",
+    )
     return parser.parse_args()
 
 
-def normalize_dataframe(df: pd.DataFrame, column: str) -> pd.DataFrame:
+def normalize_dataframe(
+    df: pd.DataFrame,
+    column: str,
+    *,
+    strip_mutations: bool,
+    mutation_whitelist: Sequence[str] | None,
+) -> pd.DataFrame:
+    """Apply ``normalize_target_name`` to a dataframe column."""
     results: List[NormalizationResult] = [
-        normalize_target_name(str(val)) for val in df[column]
+        normalize_target_name(
+            str(val),
+            strip_mutations=strip_mutations,
+            mutation_whitelist=mutation_whitelist,
+        )
+        for val in df[column]
     ]
     df = df.copy()
     df["clean_text"] = [r.clean_text for r in results]
@@ -42,12 +65,22 @@ def normalize_dataframe(df: pd.DataFrame, column: str) -> pd.DataFrame:
 
 
 def main() -> None:
+    """Entry point for the CLI interface."""
     args = parse_args()
     configure_logging(args.log_level)
     inp = Path(args.input)
     out = Path(args.output)
     df = read_target_names(inp, column=args.column)
-    df = normalize_dataframe(df, args.column)
+    extra_whitelist = None
+    if args.mutation_whitelist:
+        tokens = Path(args.mutation_whitelist).read_text().splitlines()
+        extra_whitelist = [t.strip() for t in tokens if t.strip()]
+    df = normalize_dataframe(
+        df,
+        args.column,
+        strip_mutations=not args.keep_mutations,
+        mutation_whitelist=extra_whitelist,
+    )
     write_with_new_columns(df, out)
 
 

--- a/mylib/validate.py
+++ b/mylib/validate.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import pandas as pd
+import pandas as pd  # type: ignore[import-untyped]
 
 
 def ensure_column(df: pd.DataFrame, column: str) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pandas>=2.0
 pytest>=7.0
+# optional: hgvs>=1.5

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -14,7 +14,9 @@ from mylib.transforms import (
     apply_receptor_rules,
     normalize_target_name,
     replace_specials,
+    replace_roman_numerals,
     sanitize_text,
+    normalize_unicode,
 )
 
 
@@ -23,6 +25,29 @@ def test_sanitize_and_replace():
     clean = sanitize_text(text)
     clean = replace_specials(clean)
     assert clean == "beta receptor"
+
+
+def test_translate_micro_and_superscript():
+    text = normalize_unicode("µp² receptor")
+    clean = replace_specials(text)
+    assert clean == "mup2 receptor"
+
+
+def test_replace_roman_numerals():
+    text = "type viii receptor"
+    replaced = replace_roman_numerals(text)
+    assert replaced == "type 8 receptor"
+
+
+def test_read_target_names_missing_column(tmp_path: Path) -> None:
+    csv_path = tmp_path / "x.csv"
+    csv_path.write_text("foo\n1\n2\n")
+    with pytest.raises(KeyError) as exc:
+        read_target_names(csv_path, column="bar")
+    msg = str(exc.value)
+    assert "Available columns" in msg
+    assert "foo" in msg
+    assert "1" in msg
 
 
 def test_receptor_rules():
@@ -97,7 +122,9 @@ def test_parenthetical_complex_indices():
 def test_dataframe_hints_and_rules(tmp_path: Path) -> None:
     sample = Path("tests/data/sample.csv")
     df = read_target_names(sample)
-    df_norm = normalize_dataframe(df, "target_name")
+    df_norm = normalize_dataframe(
+        df, "target_name", strip_mutations=True, mutation_whitelist=None
+    )
     assert isinstance(df_norm.loc[0, "hints"], dict)
     assert isinstance(df_norm.loc[0, "rules_applied"], list)
     out = tmp_path / "out.csv"
@@ -250,3 +277,21 @@ def test_mutation_whitelist() -> None:
         "p.*100Y",
         "p.K45delinsST",
     }
+
+
+def test_additional_mutation_patterns() -> None:
+    res = normalize_target_name("CFTR F508del")
+    assert res.clean_text == "cftr"
+    assert res.hints["mutations"] == ["F508del"]
+
+
+def test_disable_mutation_stripping() -> None:
+    res = normalize_target_name("BRAF V600E", strip_mutations=False)
+    assert "v600e" in res.query_tokens
+    assert "braf v600e" in res.clean_text.split("|")
+
+
+def test_extend_mutation_whitelist() -> None:
+    res = normalize_target_name("BRAF V600E", mutation_whitelist=["v600e"])
+    assert res.clean_text == "braf v600e"
+    assert res.hints["mutations"] == []


### PR DESCRIPTION
## Summary
- add generic deletion/frameshift patterns and optional HGVS parsing with a documented mutation whitelist
- make mutation stripping configurable via `strip_mutations` and extendable whitelist with CLI flags

## Testing
- `ruff check mylib tests main.py`
- `mypy mylib`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8b2f9bc688324831ff5005ae40104