### PR TITLE
Add UniProt validation to main normalization pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ python main.py --input target_validation_new.csv --output normalized.csv
 #   --json-columns hints,rules_applied  # columns to JSON-encode
 ```
 
+### UniProt mapping validation
+
+Supply the UniProt accession column to ``main.py`` to validate mappings:
+
+```bash
+python main.py --input target_validation_out.csv --output validated.csv \
+    --column target_name --id-column target_uniprot_id
+```
+
+Adds a boolean `uniprot_match` column indicating whether the supplied name
+matches the UniProt record for each accession.
+
 The output CSV includes columns:
 
 - `clean_text` – normalized name without stop words

--- a/library/io_utils.py
+++ b/library/io_utils.py
@@ -113,6 +113,50 @@ def read_target_names(
     return df
 
 
+def read_uniprot_mapping(
+    path: Path,
+    id_column: str,
+    name_column: str,
+    *,
+    encoding: str | None = None,
+    delimiter: str | None = None,
+) -> pd.DataFrame:
+    """Read CSV containing UniProt identifiers and protein names.
+
+    Parameters
+    ----------
+    path:
+        Path to the input CSV file.
+    id_column:
+        Column containing UniProt accession IDs.
+    name_column:
+        Column containing protein or gene names to validate.
+    encoding:
+        Optional file encoding. If ``None``, auto-detected.
+    delimiter:
+        Optional delimiter. If ``None``, auto-detected.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with at least the two specified columns.
+    """
+    if encoding is None or delimiter is None:
+        det_enc, det_delim = detect_csv_format(path)
+        encoding = encoding or det_enc
+        delimiter = delimiter or det_delim
+    df = pd.read_csv(path, encoding=encoding, sep=delimiter)
+    for col in (id_column, name_column):
+        if col not in df.columns:
+            sample = df.head().to_string(index=False)
+            cols = ", ".join(df.columns)
+            raise KeyError(
+                f"Column '{col}' not found in {path}. "
+                f"Available columns: {cols}. Sample:\n{sample}"
+            )
+    return df[[id_column, name_column]].copy()
+
+
 def write_with_new_columns(
     df: pd.DataFrame,
     path: Path,

--- a/library/uniprot.py
+++ b/library/uniprot.py
@@ -1,0 +1,67 @@
+"""UniProt client utilities.
+
+This module provides helper functions for retrieving protein information
+from the UniProt REST API.
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+from typing import Dict, List, Tuple
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=128)
+def fetch_uniprot_record(uniprot_id: str) -> Dict:
+    """Fetch UniProt entry JSON by accession.
+
+    Parameters
+    ----------
+    uniprot_id:
+        UniProt accession identifier (e.g., ``"P68871"``).
+
+    Returns
+    -------
+    dict
+        Parsed JSON payload returned by the UniProt REST API.
+
+    Raises
+    ------
+    requests.HTTPError
+        If the request fails.
+    """
+    url = f"https://rest.uniprot.org/uniprotkb/{uniprot_id}.json"
+    logger.debug("Fetching UniProt record for %s", uniprot_id)
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def extract_names(record: Dict) -> Tuple[str, List[str]]:
+    """Extract canonical protein and gene names from a UniProt record.
+
+    Parameters
+    ----------
+    record:
+        JSON object representing the UniProt entry.
+
+    Returns
+    -------
+    tuple[str, list[str]]
+        Canonical protein name and a list of gene names including synonyms.
+    """
+    protein_name = record["proteinDescription"]["recommendedName"]["fullName"]["value"]
+    gene_names: List[str] = []
+    for gene in record.get("genes", []):
+        gene_name = gene.get("geneName", {}).get("value")
+        if gene_name:
+            gene_names.append(gene_name)
+        for syn in gene.get("synonyms", []):
+            syn_val = syn.get("value")
+            if syn_val:
+                gene_names.append(syn_val)
+    return protein_name, gene_names

--- a/library/validate.py
+++ b/library/validate.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
-import pandas as pd  # type: ignore[import-untyped]
+import logging
+
+import pandas as pd
+
+from .uniprot import extract_names, fetch_uniprot_record
+
+logger = logging.getLogger(__name__)
 
 
 def ensure_column(df: pd.DataFrame, column: str) -> None:
@@ -15,3 +21,60 @@ def ensure_column(df: pd.DataFrame, column: str) -> None:
     """
     if column not in df.columns:
         raise KeyError(f"Column '{column}' is required")
+
+
+def validate_uniprot_name(uniprot_id: str, name: str) -> bool:
+    """Check whether ``name`` matches the UniProt record for ``uniprot_id``.
+
+    Parameters
+    ----------
+    uniprot_id:
+        UniProt accession.
+    name:
+        Protein or gene name to validate.
+
+    Returns
+    -------
+    bool
+        ``True`` if the provided name matches the canonical protein name or any
+        gene names/synonyms in UniProt, otherwise ``False``.
+    """
+    record = fetch_uniprot_record(uniprot_id)
+    protein_name, gene_names = extract_names(record)
+    candidates = {protein_name.lower(), *(g.lower() for g in gene_names)}
+    return name.lower() in candidates
+
+
+def validate_uniprot_dataframe(
+    df: pd.DataFrame, id_column: str, name_column: str
+) -> pd.DataFrame:
+    """Validate UniProt mappings for an entire DataFrame.
+
+    Parameters
+    ----------
+    df:
+        Input DataFrame containing UniProt IDs and protein names.
+    id_column:
+        Column with UniProt accessions.
+    name_column:
+        Column with names to validate.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Copy of ``df`` with an added boolean ``uniprot_match`` column.
+    """
+    ensure_column(df, id_column)
+    ensure_column(df, name_column)
+    matches: list[bool] = []
+    for row in df.itertuples(index=False):
+        uniprot_id = getattr(row, id_column)
+        name = getattr(row, name_column)
+        try:
+            matches.append(validate_uniprot_name(str(uniprot_id), str(name)))
+        except Exception as exc:  # pragma: no cover - network/parse issues
+            logger.warning("Validation failed for %s: %s", uniprot_id, exc)
+            matches.append(False)
+    out = df.copy()
+    out["uniprot_match"] = matches
+    return out

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-"""CLI entry point for target name normalization."""
+"""CLI entry point for target name normalization and validation."""
 
 from __future__ import annotations
 
@@ -12,6 +12,7 @@ import pandas as pd
 
 from library.io_utils import read_target_names, write_with_new_columns
 from library.transforms import NormalizationResult, normalize_target_name
+from library.validate import validate_uniprot_dataframe
 
 
 def configure_logging(level: str) -> None:
@@ -21,10 +22,16 @@ def configure_logging(level: str) -> None:
 
 def parse_args() -> argparse.Namespace:
     """Parse command-line arguments."""
-    parser = argparse.ArgumentParser(description="Normalize target names")
+    parser = argparse.ArgumentParser(
+        description="Normalize target names and optionally validate UniProt mappings"
+    )
     parser.add_argument("--input", required=True, help="Path to input CSV")
     parser.add_argument("--output", required=True, help="Path to output CSV")
     parser.add_argument("--column", default="target_name", help="Name column")
+    parser.add_argument(
+        "--id-column",
+        help="If provided, column with UniProt accessions to validate",
+    )
     parser.add_argument("--log-level", default="INFO", help="Logging level")
     parser.add_argument("--delimiter", help="CSV delimiter override")
     parser.add_argument("--encoding", help="File encoding override")
@@ -107,6 +114,11 @@ def main() -> None:
     elapsed = time.perf_counter() - start
     logging.info("Normalized %d records in %.2f s", len(df), elapsed)
     logging.info("Sample output: %s", df.head().to_dict(orient="records"))
+    if args.id_column:
+        logging.info("Validating UniProt mappings using column '%s'", args.id_column)
+        df = validate_uniprot_dataframe(df, args.id_column, args.column)
+        matches = int(df["uniprot_match"].sum())
+        logging.info("UniProt match count: %d/%d", matches, len(df))
     json_cols = (
         args.json_columns.split(",")
         if args.json_columns

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandas>=2.0
 pytest>=7.0
+requests>=2.31
 # optional: hgvs>=1.5

--- a/tests/data/uniprot_sample.csv
+++ b/tests/data/uniprot_sample.csv
@@ -1,0 +1,3 @@
+uniprot_id,protein_name
+P68871,Hemoglobin subunit beta
+P68871,Random protein

--- a/tests/test_validate_uniprot.py
+++ b/tests/test_validate_uniprot.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+import sys
+
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from library.validate import validate_uniprot_dataframe
+from main import main as cli_main
+
+
+def fake_record(_uniprot_id: str) -> dict:
+    return {
+        "proteinDescription": {
+            "recommendedName": {"fullName": {"value": "Hemoglobin subunit beta"}}
+        },
+        "genes": [{"geneName": {"value": "HBB"}, "synonyms": []}],
+    }
+
+
+def test_validate_uniprot_dataframe(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "library.validate.fetch_uniprot_record", lambda uid: fake_record(uid)
+    )
+    sample = Path("tests/data/uniprot_sample.csv")
+    df = pd.read_csv(sample)
+    result = validate_uniprot_dataframe(df, "uniprot_id", "protein_name")
+    assert bool(result.loc[0, "uniprot_match"]) is True
+    assert bool(result.loc[1, "uniprot_match"]) is False
+
+
+def test_cli_validation(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        "library.validate.fetch_uniprot_record", lambda uid: fake_record(uid)
+    )
+    sample = Path("tests/data/uniprot_sample.csv")
+    out = tmp_path / "out.csv"
+    argv = [
+        "main.py",
+        "--input",
+        str(sample),
+        "--output",
+        str(out),
+        "--column",
+        "protein_name",
+        "--id-column",
+        "uniprot_id",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    cli_main()
+    df = pd.read_csv(out)
+    assert "uniprot_match" in df.columns


### PR DESCRIPTION
## Summary
- integrate UniProt mapping validation into existing main CLI via optional `--id-column`
- remove standalone `validate_uniprot.py` script and update documentation

## Testing
- `ruff check .`
- `black --check .`
- `pytest`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_68b931145ee48324bc8847841e5eb9cd