### PR TITLE
Integrate domain parsing into main CLI

### DIFF
--- a/library/__init__.py
+++ b/library/__init__.py
@@ -2,5 +2,15 @@
 
 from .io_utils import read_target_names, write_with_new_columns
 from .transforms import normalize_target_name
+from .domain_parser import parse_domain
+from .domain_dictionaries import DOMAIN_TYPE_MAP, DOMAIN_LOC_MAP, normalize_text
 
-__all__ = ["read_target_names", "write_with_new_columns", "normalize_target_name"]
+__all__ = [
+    "read_target_names",
+    "write_with_new_columns",
+    "normalize_target_name",
+    "parse_domain",
+    "DOMAIN_TYPE_MAP",
+    "DOMAIN_LOC_MAP",
+    "normalize_text",
+]

--- a/library/domain_dictionaries.py
+++ b/library/domain_dictionaries.py
@@ -1,0 +1,84 @@
+"""Dictionaries for domain type and localization normalization.
+
+The dictionaries map various textual representations of domains and
+localizations to canonical tags. Keys are normalized using
+:func:`normalize_text` to ensure consistent matching.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+import re
+
+
+def normalize_text(text: str) -> Tuple[str, List[str]]:
+    """Normalize a domain description fragment.
+
+    Parameters
+    ----------
+    text: str
+        Raw text describing a domain.
+
+    Returns
+    -------
+    tuple[str, list[str]]
+        A tuple of the normalized text and a list of normalization
+        reason codes applied during processing.
+    """
+    reasons: List[str] = []
+    s = re.sub(r"[-_]+", " ", text.lower())
+    s = re.sub(r"(?:^| )(c|n)terminal\b", r" \1 terminal", s)
+    s = s.replace("cterminal", "c terminal").replace("ndomain", "n domain")
+    s = s.replace("cmet", "c met").replace("cdomain", "c domain")
+
+    def _replace_bromo(match: re.Match[str]) -> str:
+        digit = match.group(2)
+        if digit == "1":
+            reasons.append("NORM_SLUG_BROMO1")
+        elif digit == "2":
+            reasons.append("NORM_SLUG_BROMO2")
+        return f"{match.group(1)} {digit}"
+
+    s = re.sub(r"(bromodomain)(\d)", _replace_bromo, s)
+    s = re.sub(r"(domain)(\d)", r"\1 \2", s)
+    s = re.sub(r"\s+", " ", s).strip()
+    return s, reasons
+
+
+_RAW_DOMAIN_TYPES: Dict[str, str] = {
+    "KD": "kinase domain|tyrosine kinase domain|ptk domain|catalytic domain",
+    "LBD": "ligand binding domain|lbd|hormone binding domain",
+    "DBD": "dna binding domain|dbd|zf domain|zinc finger",
+    "BROMO": "bromodomain|bromo domain|bd",
+    "BROMO_BD1": "bromodomain1|bromo domain 1|bromo domain-1|bd1|domain1|domain-1",
+    "BROMO_BD2": "bromodomain2|bromo domain 2|bromo domain-2|bd2|domain2|domain-2",
+    "MOTOR": "motor domain",
+    "ECD": "ectodomain|ecd|extracellular domain",
+    "BROMO_TANDEM": "tandem domain|tandem bromodomain",
+    "GYRB": "gyrb domain",
+    "KI": "kinase insert|ki domain",
+    "PKD": "pseudokinase domain",
+    "TMD": "transmembrane domain|tm domain|tmd",
+}
+
+_RAW_DOMAIN_LOCS: Dict[str, str] = {
+    "ICD": "cytoplasmic domain|intracellular domain|icd",
+    "ECD": "extracellular domain|ecto domain|ectodomain|ecd",
+    "C_TERM": "c-terminal domain|c terminal domain|c-domain|cdomain|cterminal",
+    "N_TERM": "n-terminal domain|n terminal domain|n-domain|ndomain|nterminal",
+}
+
+
+def _build_dict(raw_map: Dict[str, str]) -> Dict[str, str]:
+    result: Dict[str, str] = {}
+    for canonical, aliases in raw_map.items():
+        for alias in aliases.split("|"):
+            normalized, _ = normalize_text(alias)
+            result[normalized] = canonical
+    return result
+
+
+DOMAIN_TYPE_MAP: Dict[str, str] = _build_dict(_RAW_DOMAIN_TYPES)
+DOMAIN_LOC_MAP: Dict[str, str] = _build_dict(_RAW_DOMAIN_LOCS)
+
+__all__ = ["DOMAIN_TYPE_MAP", "DOMAIN_LOC_MAP", "normalize_text"]

--- a/library/domain_parser.py
+++ b/library/domain_parser.py
@@ -1,0 +1,148 @@
+"""Utilities for parsing domain descriptions.
+
+This module provides functions to normalize textual descriptions of
+protein domains and to map them to canonical domain type and
+localization tags.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Union
+import logging
+import re
+
+from .domain_dictionaries import DOMAIN_TYPE_MAP, DOMAIN_LOC_MAP, normalize_text
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class DomainParseResult:
+    """Parsed information for a domain description."""
+
+    domain_type: Optional[str] = None
+    domain_loc: List[str] = field(default_factory=list)
+    domain_index: Optional[Union[int, List[int]]] = None
+    domain_source_variant: Optional[str] = None
+    domain_reason: List[str] = field(default_factory=list)
+
+
+_TYPE_PRIORITY = {
+    "BROMO_BD1": 1,
+    "BROMO_BD2": 2,
+    "BROMO_TANDEM": 3,
+    "BROMO": 4,
+    "KD": 5,
+    "LBD": 6,
+    "DBD": 7,
+    "MOTOR": 8,
+    "GYRB": 9,
+    "PKD": 10,
+    "KI": 11,
+    "TMD": 12,
+    "ECD": 13,
+    "ICD": 14,
+    "N_TERM": 15,
+    "C_TERM": 16,
+}
+
+_LOC_PRIORITY = {"ICD": 1, "ECD": 2, "C_TERM": 3, "N_TERM": 4}
+
+_DROPPED_WORDS = {"receptor", "mutant", "protein", "subtype"}
+
+
+def _match_from_dict(
+    text: str, lookup: dict[str, str], priority: dict[str, int]
+) -> Optional[str]:
+    """Return the best canonical tag found in *lookup* for *text*."""
+    matches: List[str] = []
+    for alias, canonical in lookup.items():
+        tokens = [re.escape(tok) for tok in alias.split()]
+        pattern = r"\b" + r"\s+".join(tokens) + r"\b"
+        if re.search(pattern, text):
+            matches.append(canonical)
+    if not matches:
+        return None
+    return min(matches, key=lambda c: priority.get(c, 100))
+
+
+def parse_domain(text: str) -> DomainParseResult:
+    """Parse domain information from *text*.
+
+    Parameters
+    ----------
+    text: str
+        Raw string possibly describing a protein domain.
+
+    Returns
+    -------
+    DomainParseResult
+        Structured information about the detected domain.
+    """
+    result = DomainParseResult()
+    if not text:
+        return result
+
+    normalized, norm_reasons = normalize_text(text)
+    variants = [v.strip() for v in normalized.split("|") if v.strip()]
+    for variant in variants:
+        cleaned = re.sub(
+            r"\b(" + "|".join(_DROPPED_WORDS) + r")\b", "", variant
+        ).strip()
+        if not cleaned:
+            continue
+
+        domain_type = _match_from_dict(cleaned, DOMAIN_TYPE_MAP, _TYPE_PRIORITY)
+        domain_loc = _match_from_dict(cleaned, DOMAIN_LOC_MAP, _LOC_PRIORITY)
+        index: Optional[Union[int, List[int]]] = None
+
+        if domain_type == "BROMO":
+            if re.search(r"\b1\b", cleaned):
+                domain_type = "BROMO_BD1"
+                index = 1
+                result.domain_reason.append("DERIVED_FROM_BROMODOMAIN1")
+            elif re.search(r"\b2\b", cleaned):
+                domain_type = "BROMO_BD2"
+                index = 2
+                result.domain_reason.append("DERIVED_FROM_BROMODOMAIN2")
+
+        if domain_type in {"BROMO_BD1", "BROMO_BD2"} and index is None:
+            index = 1 if domain_type.endswith("BD1") else 2
+
+        if domain_type == "BROMO_TANDEM" and re.search(r"\bbrd4\b", cleaned):
+            index = [1, 2]
+
+        if index is None:
+            m = re.search(r"\bdomain\s*([0-9]+)\b", cleaned)
+            if m:
+                index = int(m.group(1))
+
+        if domain_type or domain_loc or index is not None:
+            result.domain_source_variant = variant
+            if norm_reasons:
+                result.domain_reason.extend(norm_reasons)
+            if domain_type:
+                if not result.domain_type or _TYPE_PRIORITY[
+                    domain_type
+                ] < _TYPE_PRIORITY.get(result.domain_type, 100):
+                    result.domain_type = domain_type
+                result.domain_reason.append(f"MATCH_TYPE_{domain_type}")
+            if domain_loc:
+                if domain_loc not in result.domain_loc:
+                    result.domain_loc.append(domain_loc)
+                result.domain_reason.append(f"MATCH_LOC_{domain_loc}")
+            if index is not None:
+                result.domain_index = index
+
+    if (
+        not result.domain_type
+        and not result.domain_loc
+        and re.search(r"\bdomain\b", normalized)
+    ):
+        result.domain_reason.append("FALLBACK_DOMAIN_WORD")
+
+    return result
+
+
+__all__ = ["parse_domain", "DomainParseResult"]

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ import pandas as pd
 from library.io_utils import read_target_names, write_with_new_columns
 from library.transforms import NormalizationResult, normalize_target_name
 from library.validate import validate_uniprot_dataframe
+from library.domain_parser import parse_domain
 
 
 def configure_logging(level: str) -> None:
@@ -54,6 +55,10 @@ def parse_args() -> argparse.Namespace:
         "--json-columns",
         help="Comma-separated columns to serialize as JSON when writing",
     )
+    parser.add_argument(
+        "--domain-column",
+        help="Optional column with domain descriptions to parse",
+    )
     return parser.parse_args()
 
 
@@ -84,12 +89,43 @@ def normalize_dataframe(
     df["gene_like_candidates"] = [" ".join(r.gene_like_candidates) for r in results]
     df["hints"] = [r.hints for r in results]
     df["mutation_classes"] = [
-        "|".join(cast(List[str], r.hints.get("mutation_classes", [])))
-        for r in results
+        "|".join(cast(List[str], r.hints.get("mutation_classes", []))) for r in results
     ]
     df["rules_applied"] = [r.rules_applied for r in results]
     df["hint_taxon"] = [r.hint_taxon for r in results]
     df["domains"] = ["|".join(r.domains) for r in results]
+    return df
+
+
+def add_domain_columns(df: pd.DataFrame, column: str) -> pd.DataFrame:
+    """Parse domain descriptions from *column* and append structured data.
+
+    Parameters
+    ----------
+    df:
+        Input dataframe containing a column with raw domain descriptions.
+    column:
+        Name of the column in ``df`` to parse.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Copy of ``df`` with additional columns ``domain_type``,
+        ``domain_loc``, ``domain_index``, ``domain_source_variant`` and
+        ``domain_reason``.
+    """
+
+    results = [parse_domain(str(v)) for v in df[column]]
+    df = df.copy()
+    df["domain_type"] = [r.domain_type for r in results]
+    df["domain_loc"] = [
+        "|".join(r.domain_loc) if r.domain_loc else None for r in results
+    ]
+    df["domain_index"] = [r.domain_index for r in results]
+    df["domain_source_variant"] = [r.domain_source_variant for r in results]
+    df["domain_reason"] = [
+        "|".join(r.domain_reason) if r.domain_reason else None for r in results
+    ]
     return df
 
 
@@ -116,6 +152,13 @@ def main() -> None:
         detect_mutations=not args.no_mutations,
         taxon=args.taxon,
     )
+    if args.domain_column:
+        if args.domain_column not in df.columns:
+            raise ValueError(
+                f"Domain column '{args.domain_column}' not found in input file."
+            )
+        logging.info("Parsing domain descriptions from column '%s'", args.domain_column)
+        df = add_domain_columns(df, args.domain_column)
     elapsed = time.perf_counter() - start
     logging.info("Normalized %d records in %.2f s", len(df), elapsed)
     logging.info("Sample output: %s", df.head().to_dict(orient="records"))

--- a/tests/test_domain_parser.py
+++ b/tests/test_domain_parser.py
@@ -1,0 +1,48 @@
+"""Tests for domain parsing utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Any
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from library.domain_parser import parse_domain
+
+
+def _extract(result: Any) -> tuple[Any, list[str], Any]:
+    """Helper to extract fields of interest."""
+    return result.domain_type, result.domain_loc, result.domain_index
+
+
+@pytest.mark.parametrize(
+    "text,expected_type,expected_loc,expected_index",
+    [
+        ("ace c-domain", None, ["C_TERM"], None),
+        ("ace n-domain", None, ["N_TERM"], None),
+        ("alk cytoplasmic domain", None, ["ICD"], None),
+        ("alk kinase domain", "KD", [], None),
+        ("androgen receptor lbd domain", "LBD", [], None),
+        ("ar ligand binding domain", "LBD", [], None),
+        ("brd4 bromo domain 1", "BROMO_BD1", [], 1),
+        ("brd4 bromodomain2", "BROMO_BD2", [], 2),
+        ("brd4 tandem domain", "BROMO_TANDEM", [], [1, 2]),
+        (
+            "egfr cytoplasmic domain l858r / t790m mutant",
+            None,
+            ["ICD"],
+            None,
+        ),
+    ],
+)
+def test_parse_domain(
+    text: str, expected_type: Any, expected_loc: list[str], expected_index: Any
+) -> None:
+    result = parse_domain(text)
+    domain_type, domain_loc, domain_index = _extract(result)
+    assert domain_type == expected_type
+    assert domain_loc == expected_loc
+    assert domain_index == expected_index

--- a/tests/test_main_domain.py
+++ b/tests/test_main_domain.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from main import add_domain_columns
+
+
+def test_add_domain_columns() -> None:
+    df = pd.DataFrame({"domain": ["ace c-domain", "alk kinase domain"]})
+    out = add_domain_columns(df, "domain")
+    assert list(out["domain_loc"]) == ["C_TERM", None]
+    assert list(out["domain_type"]) == [None, "KD"]


### PR DESCRIPTION
## Summary
- move domain dictionaries into the library package
- merge domain parsing CLI into `main.py` with a `--domain-column` option
- add tests for DataFrame domain column processing

## Testing
- `python -m black .`
- `ruff check .`
- `python -m mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf694802d08324b69bf10fb0f09f79